### PR TITLE
Fix the timetag format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/scgolang/osc
+
+go 1.19
+
+require (
+	github.com/imdario/go-ulid v0.0.0-20180116185620-aeb52bf96595
+	github.com/pkg/errors v0.9.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/imdario/go-ulid v0.0.0-20180116185620-aeb52bf96595 h1:8MKHx/6AMMFGslqvr37RF7zktr3eJmY1z2FKdq3Zo/o=
+github.com/imdario/go-ulid v0.0.0-20180116185620-aeb52bf96595/go.mod h1:ugPCasYVpR6Cf8xlF0vkZdVKntj7zTgo9pLR4Si7Boo=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/lolatency_test.go
+++ b/lolatency_test.go
@@ -36,7 +36,7 @@ func BenchmarkUDPSend(b *testing.B) {
 		ch  = make(chan struct{})
 		val = struct{}{}
 	)
-	go srv.Serve(8, osc.Dispatcher{
+	go srv.Serve(8, osc.PatternMatching{
 		"/ping": osc.Method(func(m osc.Message) error {
 			ch <- val
 			return nil
@@ -74,7 +74,7 @@ func BenchmarkUDPSendOneArgument(b *testing.B) {
 		ch  = make(chan struct{})
 		val = struct{}{}
 	)
-	go srv.Serve(1, osc.Dispatcher{
+	go srv.Serve(1, osc.PatternMatching{
 		"/ping": osc.Method(func(m osc.Message) error {
 			if _, err := m.Arguments[0].ReadInt32(); err != nil {
 				return err
@@ -117,7 +117,7 @@ func BenchmarkUnixSend(b *testing.B) {
 		ch  = make(chan struct{})
 		val = struct{}{}
 	)
-	go srv.Serve(8, osc.Dispatcher{
+	go srv.Serve(8, osc.PatternMatching{
 		"/ping": osc.Method(func(m osc.Message) error {
 			ch <- val
 			return nil
@@ -154,7 +154,7 @@ func BenchmarkUDPSendExactMatch(b *testing.B) {
 		ch  = make(chan struct{})
 		val = struct{}{}
 	)
-	go srv.Serve(1, osc.Dispatcher{
+	go srv.Serve(1, osc.PatternMatching{
 		"/ping": osc.Method(func(m osc.Message) error {
 			if _, err := m.Arguments[0].ReadInt32(); err != nil {
 				return err

--- a/timetag.go
+++ b/timetag.go
@@ -10,8 +10,9 @@ import (
 
 const (
 	// SecondsFrom1900To1970 is exactly what it sounds like.
-	SecondsFrom1900To1970 = 2208988800
-	// SecondsFrom1900To1970 = 2207520000
+	SecondsFrom1900To1970 = 2208988800 // Source: RFC 868
+
+	nanosecondsPerFraction = float64(0.23283064365386962891) // 1e9/(2^32)
 
 	// TimetagSize is the number of 8-bit bytes in an OSC timetag.
 	TimetagSize = 8
@@ -43,15 +44,30 @@ func (tt Timetag) String() string {
 
 // Time converts an OSC timetag to a time.Time.
 func (tt Timetag) Time() time.Time {
-	secs := (uint64(tt) >> 32) - SecondsFrom1900To1970
-	return time.Unix(int64(secs), int64(tt)&0xFFFFFFFF).UTC()
+	t := uint64(tt)
+
+	if t == 1 {
+		// Means "immediately". It cannot occur otherwise as timetag == 0 gets
+		// converted to January 1, 1900 while time.Time{} means year 1 in Go.
+		// Use the time.Time.IsZero() method to detect it.
+		return time.Time{}
+	}
+
+	return time.Unix(
+		int64(t>>32)-SecondsFrom1900To1970,
+		int64(nanosecondsPerFraction*float64(t&(1<<32-1))),
+	).UTC()
 }
 
 // FromTime converts the given time to an OSC timetag.
 func FromTime(t time.Time) Timetag {
-	t = t.UTC()
-	secs := uint64((SecondsFrom1900To1970 + t.Unix()) << 32)
-	return Timetag(secs + uint64(uint32(t.Nanosecond())))
+	if t.IsZero() {
+		return 1
+	}
+
+	seconds := uint64(t.Unix() + SecondsFrom1900To1970)
+	secondFraction := float64(t.UTC().Nanosecond()) / nanosecondsPerFraction
+	return Timetag((seconds << 32) + uint64(uint32(secondFraction)))
 }
 
 // ReadTimetag parses a timetag from a byte slice.
@@ -59,14 +75,7 @@ func ReadTimetag(data []byte) (Timetag, error) {
 	if len(data) < TimetagSize {
 		return Timetag(0), errors.New("timetags must be 64-bit")
 	}
-	zero := []byte{0, 0, 0, 0}
-	var (
-		L     = append(zero, data[:TimetagSize/2]...)
-		R     = append(zero, data[TimetagSize/2:]...)
-		secs  uint64
-		nsecs uint64
-	)
-	_ = binary.Read(bytes.NewReader(L), byteOrder, &secs)  // Never fails
-	_ = binary.Read(bytes.NewReader(R), byteOrder, &nsecs) // Never fails
-	return Timetag((secs << 32) + nsecs), nil
+	var tt uint64
+	_ = binary.Read(bytes.NewReader(data), binary.BigEndian, &tt)
+	return Timetag(tt), nil
 }


### PR DESCRIPTION
Fixes #6 

The spec indicates that the lower 32-bits of a timetag are fractions of a second. They were previously handled as nanoseconds. A fraction is 1/(2^32) s ~= 0.233ns, so the difference is pretty big.

Also added Go modules so that compilation is easy, versions were picked automatically by `go mod init github.com/scgolang/osc ; go mod tidy`. Fixed some things in `lolatency_test.go` as well, it seems `Dispatcher` became an interface and its implementation now is called `PatternMatching`.

It would be nice if those changes could be tested in a running OSC system. I don't have anything at hand, I'm sorry that I'm providing non-field-tested code.

I kept `SecondsFrom1900To1970` exposed to avoid breaking the API. `ReadTimetag` was way too complex for no reason: the spec indicates big endian. It wouldn't have worked anyway in little endian (both secs and nsecs would have been zero because of the byte inversion and because they are both 32 bits).

Hoping this can be useful to someone. :) I don't use the lib, I just like OSC and wanted to send a patch to some open-source project. Please don't hesitate reviewing and doubting my changes.