### PR TITLE
ToBytes, return []byte{0,0,0,0} when string is empty

### DIFF
--- a/osc.go
+++ b/osc.go
@@ -44,8 +44,8 @@ type Packet interface {
 // This means that the returned byte slice is padded with null bytes
 // so that it's length is a multiple of 4.
 func ToBytes(s string) []byte {
-	if len(s) == 0 {
-		return []byte{}
+	if s == "" {
+		return []byte{0, 0, 0, 0}
 	}
 	return Pad(append([]byte(s), 0))
 }

--- a/osc_test.go
+++ b/osc_test.go
@@ -12,7 +12,7 @@ func TestToBytes(t *testing.T) {
 	}{
 		{
 			Input:    "",
-			Expected: []byte{},
+			Expected: []byte{0, 0, 0, 0},
 		},
 		{
 			Input:    "a",


### PR DESCRIPTION
Fixes https://github.com/scgolang/osc/issues/17

Maybe the library needs a validate function to make sure the msg.Address is not empty. 